### PR TITLE
Resolve macOS binary compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,4 @@ matrix:
     - SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 install: ./travis/dependencies.sh
 script: ./travis/build.sh
+before_deploy: ./travis/bundle.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
   homebrew:
     update: true
     packages:
+    - dylibbundler
     - protobuf
     - sdl2
     - sdl2_image
@@ -47,8 +48,20 @@ matrix:
     env: 
     - CC=gcc-9 
     - CXX=g++-9
-  - name: "macOS Mojave"
+  - name: "Mojave LLVM"
     os: osx
-    osx_image: xcode10.2
+    osx_image: xcode10.3
+    env:
+    - CXX="/usr/local/opt/llvm/bin/clang++"
+    - MACOSX_DEPLOYMENT_TARGET=10.11
+    - CXXFLAGS="-I/usr/local/opt/llvm/include"
+    - LDFLAGS="-L/usr/local/opt/llvm/lib"
+  - name: "Mojave GCC"
+    os: osx
+    osx_image: xcode10.3
+    env:
+    - CXX=g++-9
+    - MACOSX_DEPLOYMENT_TARGET=10.11
+    - SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 install: ./travis/dependencies.sh
 script: ./travis/build.sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The YGOpen project aims to create a free-as-in-freedom, cleanly-engineered, cros
   - Windows: [Visual Studio](https://visualstudio.microsoft.com/)
   - macOS and Linux: GCC or Clang
 
-- On macOS, use [Homebrew](https://brew.sh/) to get the prerequisites with `brew install cmake`. If building with GCC, additionally do `brew install gcc`.
+- On macOS, use [Homebrew](https://brew.sh/) to get the prerequisites with `brew install cmake`. If building on 10.13 or later, but you want compatibility with older versions (back to 10.11 has been tested), you can get `llvm` or `gcc`, which ship with their own C++ standard libraries, from `brew` in the same fashion. Additionally, you might want to install an older SDK to target from [here](https://github.com/phracker/MacOSX-SDKs).
 - On Windows, set up [`vcpkg`](https://github.com/microsoft/vcpkg). It is recommended to set environment variable `VCPKG_ROOT` to the install location for convenience.
 
 ## Dependencies
@@ -38,4 +38,6 @@ On Linux, do `cmake .. && make`.
 
 On Windows, do `cmake .. -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake` to create the solution files and then build from the generated Visual Studio `.sln` file.
 
-On macOS, do `cmake .. && make` to build with Clang. If building with GCC, do `cmake .. -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_EXE_LINKER_FLAGS=-lc++ && make` instead.
+On macOS, do `cmake .. && make` to build with Clang. 
+If building with LLVM for backward compatibility, do `cmake .. -DCMAKE_CXX_FLAGS="-I/usr/local/opt/llvm/include" -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/llvm/lib" -DCMAKE_CXX_COMPILER="/usr/local/opt/llvm/bin/clang++" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11` as your `cmake` command, or set the corresponding environment variables `CXXFLAGS`, `LDFLAGS`, `CXX`, and `MACOSX_DEPLOYMENT_TARGET`. This will also match the SDK version, but you can explicitly set that path with `-DCMAKE_OSX_SYSROOT` and environment variable `SDKROOT`.
+If building with GCC, the custom include and library path are not needed. Just set your compiler to `g++-9`. GCC overrides some system headers in the current version, so set `SDKROOT` back to the default at `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`. Only the deployment target flag, which controls the `-mmacosx-version-min` compiler flag, will affect the resulting binary compatibility, so using a newer SDK should not be a problem. (Other software is also compiled like this, but we should be careful about compatibility implications or use the LLVM configuration as the standard.)

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -14,5 +14,5 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	cmake .. -DYGOPEN_GUI_USE_SYSTEM_FMT=OFF -DYGOPEN_GUI_USE_SYSTEM_JSON=OFF && make;
 fi
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-	cmake .. && make;
+	cmake .. && make VERBOSE=1;
 fi

--- a/travis/bundle.sh
+++ b/travis/bundle.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    cd build
+    mkdir -p ygopen-gui.app/Contents/MacOS
+    cp ygopen-gui ygopen-gui.app/Contents/MacOS
+    dylibbundler -x ygopen-gui.app/Contents/MacOS/ygopen-gui -b -d ygopen-gui.app/Contents/MacOS -p @executable_path/
+fi

--- a/travis/dependencies.sh
+++ b/travis/dependencies.sh
@@ -17,9 +17,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	git clone --depth=1 https://github.com/nlohmann/json.git
 fi
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-	if [[ "$CXX" == "g++-9" ]]; then
-		brew install gcc
-	else
+	if [[ "$CXX" == "/usr/local/opt/llvm/bin/clang++" ]]; then
 		brew install llvm
 		curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://raw.githubusercontent.com/edo9300/ygopro/master/build-support/install-macOS-sdk.sh
 		chmod +x install-macOS-sdk.sh

--- a/travis/dependencies.sh
+++ b/travis/dependencies.sh
@@ -16,3 +16,13 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	git clone --depth=1 https://github.com/fmtlib/fmt.git &
 	git clone --depth=1 https://github.com/nlohmann/json.git
 fi
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+	if [[ "$CXX" == "g++-9" ]]; then
+		brew install gcc
+	else
+		brew install llvm
+		curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://raw.githubusercontent.com/edo9300/ygopro/master/build-support/install-macOS-sdk.sh
+		chmod +x install-macOS-sdk.sh
+		./install-macOS-sdk.sh $MACOSX_DEPLOYMENT_TARGET
+	fi
+fi


### PR DESCRIPTION
- Set target platform and SDK
- Use brew's LLVM and GCC over the Xcode toolchain for C++ to ensure compatibility for before High Sierra